### PR TITLE
Install kmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
     apt-get -y install -q \
     python3 \
     build-essential \
+    kmod \
     libtool \
     python3-pip \
     libelf-dev \


### PR DESCRIPTION
When doing make modules_install, I got:
Warning: 'make modules_install' requires depmod. Please install it.
This is probably in the kmod package.