### PR TITLE
Fetch Gentoo Linux Release Engineering key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
     python3 \
     build-essential \
     kmod \
+    gnupg \
     libtool \
     python3-pip \
     libelf-dev \
@@ -57,3 +58,6 @@ ARG LAVA_SERVER
 RUN mkdir -p ~/.config/
 RUN printf 'buildbot:\n  uri: http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2' > ~/.config/lavacli.yaml
 RUN lavacli identities add --uri http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2 buildbot
+
+# See https://www.gentoo.org/downloads/signatures/
+RUN gpg --keyserver hkps://keys.gentoo.org --receive-keys 13EBBDBEDE7A12775DFDB1BABB572E0E2D182910


### PR DESCRIPTION
For checking rootfs signature, we need to fetch the Gentoo Linux Release Engineering  public GPG key.