### PR TITLE
Install and select clang 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y dist-upgrade && \
     apt-get -y install -q \
+    clang clang-11 llvm llvm-11 lld lld-11 \
     python3 \
     build-essential \
     kmod \
@@ -25,6 +26,8 @@ RUN apt-get update && \
     vim \
     autoconf \
     && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100
 
 # Install python required packages
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
Linux kernel need at least clang 10.0.0.1, but clang/clang-10 only
provides 10.0.0.0. So we need to use clang-11.
So install clang-11 along with llvm-11 and lld-11.

Also using update-alternative to force clang being clang-11.