### PR TITLE
Update llvm/lld to 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,9 @@ WORKDIR /buildbot
 COPY .kernelci-ci-gkernelci.json /home/buildbot/.kernelci-ci-gkernelci.json
 ARG GOOGLE_APPLICATION_CREDENTIALS=~/.kernelci-ci-gkernelci.json
 
+COPY update-llvm.sh /
+RUN apt-get -y remove llvm lld && sh /update-llvm.sh
+
 # Getting lava settings from docker-compose.yml
 ARG LAVA_TOKEN
 ARG LAVA_USER

--- a/update-llvm.sh
+++ b/update-llvm.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# find all llvm lld binaries and create symlink for them
+
+find /usr/bin/ -iname 'llvm-*-11' |
+while read line
+do
+	BASE_NAME=$(echo $line | sed 's,-11$,,')
+	echo "LINK $line to $BASE_NAME"
+	ln -s $line $BASE_NAME
+done
+
+find /usr/bin/ -iname '*lld-*-11' |
+while read line
+do
+	BASE_NAME=$(echo $line | sed 's,-11$,,')
+	echo "LINK $line to $BASE_NAME"
+	ln -s $line $BASE_NAME
+done
+
+find /usr/bin/ -iname '*lld-11' |
+while read line
+do
+	BASE_NAME=$(echo $line | sed 's,-11$,,')
+	echo "LINK $line to $BASE_NAME"
+	ln -s $line $BASE_NAME
+done


### PR DESCRIPTION
Building with clang-11 and llvm-10/lld-10 lead to segfault on 5.4.
So we need to upgrade them to 11.
But only clang has an update-alternative, so we need to upgrade at hand.