### PR TITLE
Do not run buildbot as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN pip3 install --use-deprecated=legacy-resolver git+https://github.com/kernelc
 RUN mkdir -p /var/www/fileserver
 RUN chown -R buildbot /var/www/fileserver
 
+ARG DOCKER_GID
+RUN groupmod -g $DOCKER_GID docker
+RUN usermod --append -G docker buildbot
+
 USER root
 WORKDIR /buildbot
 
@@ -66,6 +70,7 @@ ARG LAVA_TOKEN
 ARG LAVA_USER
 ARG LAVA_SERVER
 
+USER buildbot
 RUN mkdir -p ~/.config/
 RUN printf 'buildbot:\n  uri: http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2' > ~/.config/lavacli.yaml
 RUN lavacli identities add --uri http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2 buildbot


### PR DESCRIPTION
All compilation stuff could be done as buildbot user.
Only docker actions need spetial handling.
They do not need to be root, but running root permits to read docker socket in /run.
So we need to allow buildbot user to read it by adding to it the docker group.
BUT docker group of host and container could have a different GID.
So we need to sync GID of container to what host uses.

We cannot do anything at runtime (too complex to hack buildbot entrypoint)
so we need to did this "sync" at build time via a docker ARG.

Closes: #5