### PR TITLE
Deploy a labs.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,5 +75,7 @@ RUN mkdir -p ~/.config/
 RUN printf 'buildbot:\n  uri: http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2' > ~/.config/lavacli.yaml
 RUN lavacli identities add --uri http://$LAVA_USER:$LAVA_TOKEN@$LAVA_SERVER/RPC2 buildbot
 
+COPY labs.yaml /home/buildbot
+
 # See https://www.gentoo.org/downloads/signatures/
 RUN gpg --keyserver hkps://keys.gentoo.org --receive-keys 13EBBDBEDE7A12775DFDB1BABB572E0E2D182910

--- a/labs.yaml.example
+++ b/labs.yaml.example
@@ -1,0 +1,3 @@
+labs:
+  - name: gentoo
+    lavauri: https://user:token@lava.url/RPC2/


### PR DESCRIPTION
Current situation made impossible to use more than one LAVA lab.
So install a labs.yaml which will be used for iterating over a list of labs.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>